### PR TITLE
fix 'const NodeName' in the generated confg

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - init-icinga2
     environment:
       ICINGA_MASTER: 1
+      HOST_NAME: icinga2
     image: icinga/icinga2
     logging: *default-logging
     ports:


### PR DESCRIPTION
Force correct hostname to be set in the /etc/icinga2/constants.conf, `const NodeName = "XXXX"` so the XXX to be the icinga2 container hostname 