### PR TITLE
Podman Compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,41 @@ Icinga Web is provided on port **8080** and you can access the Icinga 2 API on p
 The default user of Icinga Web is `icingaadmin` with password `icinga` and
 the default user of the Icinga 2 API for Web is `icingaweb` with password `icingaweb`.
 
+### Use with podman
+
+Environment:
+ * ``podman version 4.0.2``
+ * ``docker-compose version 1.29.2, build 5becea4c``
+
+Ensure you have started the podman socket and set the environment variable
+````bash
+systemctl enable podman.socket --now
+export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock
+echo "export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock" >> ~/.bashrc
+````
+
+Furthermore you need an older docker-compose version:
+````bash
+wget https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -O /usr/local/sbin/docker-compose1.29.2
+````
+
+#### Podman Rootless
+
+To use the container rootless, you have to create the user environent first
+````bash
+useradd -m -c "User for icinga containers" pod_icinga
+sudo -iu pod_icinga
+echo 'export XDG_RUNTIME_DIR="/run/user/$UID"' >> ~/.bashrc
+echo 'export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"' >> ~/.bashrc
+echo "export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock" >> ~/.bashrc
+````
+
+Enable lingering for user (**as root**). If you forget this step, the containers will be stopped if the user logs out.
+````bash
+loginctl enable-linger pod_icinga_cluster
+````
+
+
 ## Upgrading from v1.1.0 to v1.2.0
 
 **v1.2.0** deploys Icinga Web ≥ 2.11.0, Icinga 2 ≥ 2.13.4, Icinga DB ≥ 1.0.0 and Icinga DB Web ≥ 1.0.0.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock
 echo "export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock" >> ~/.bashrc
 ````
 
-Furthermore you need an older docker-compose version:
+Furthermore you need an older docker-compose version (because of compability to [podman](https://github.com/containers/podman/issues/11822)):
 ````bash
 wget https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -O /usr/local/sbin/docker-compose1.29.2
 ````
@@ -42,6 +42,12 @@ echo "export DOCKER_HOST=unix:///run/user/$UID/podman/podman.sock" >> ~/.bashrc
 Enable lingering for user (**as root**). If you forget this step, the containers will be stopped if the user logs out.
 ````bash
 loginctl enable-linger pod_icinga_cluster
+````
+
+To start the container use now the following command:
+````bash
+# Change directory to the git_clone
+/usr/local/sbin/docker-compose1.29.2 up -d
 ````
 
 
@@ -64,3 +70,4 @@ The easiest way to upgrade is to start over, removing all the volumes and
 therefore wiping out any configurations you have changed:
 
 `docker-compose down --volumes && docker-compose build --pull && docker-compose -p icinga-playground up -d`
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,16 @@
 version: '3.7'
 
+x-icingadb-redis-host: &icingadb-redis-host icingadb-redis
+x-icingadb-host: &icingadb-host icingadb
+x-icinga2-host: &icinga2-host icinga2
+x-mysql-host: &mysql-host mysql
+
 x-icinga-db-web-config:
   &icinga-db-web-config
   icingaweb.modules.icingadb.config.icingadb.resource: icingadb
-  icingaweb.modules.icingadb.redis.redis1.host: icingadb-redis
+  icingaweb.modules.icingadb.redis.redis1.host: *icingadb-redis-host
   icingaweb.modules.icingadb.redis.redis1.port: 6379
-  icingaweb.modules.icingadb.commandtransports.icinga2.host: icinga2
+  icingaweb.modules.icingadb.commandtransports.icinga2.host: *icinga2-host
   icingaweb.modules.icingadb.commandtransports.icinga2.port: 5665
   icingaweb.modules.icingadb.commandtransports.icinga2.password: ${ICINGAWEB_ICINGA2_API_USER_PASSWORD:-icingaweb}
   icingaweb.modules.icingadb.commandtransports.icinga2.transport: api
@@ -13,7 +18,7 @@ x-icinga-db-web-config:
   icingaweb.resources.icingadb.charset: utf8mb4
   icingaweb.resources.icingadb.db: mysql
   icingaweb.resources.icingadb.dbname: icingadb
-  icingaweb.resources.icingadb.host: mysql
+  icingaweb.resources.icingadb.host: *mysql-host
   icingaweb.resources.icingadb.password: ${ICINGADB_MYSQL_PASSWORD:-icingadb}
   icingaweb.resources.icingadb.type: db
   icingaweb.resources.icingadb.username: icingadb
@@ -22,14 +27,14 @@ x-icinga-director-config:
   &icinga-director-config
   icingaweb.modules.director.config.db.resource: director-mysql
   icingaweb.modules.director.kickstart.config.endpoint: icinga2
-  icingaweb.modules.director.kickstart.config.host: icinga2
+  icingaweb.modules.director.kickstart.config.host: *icinga2-host
   icingaweb.modules.director.kickstart.config.port: 5665
   icingaweb.modules.director.kickstart.config.username: icingaweb
   icingaweb.modules.director.kickstart.config.password: ${ICINGAWEB_ICINGA2_API_USER_PASSWORD:-icingaweb}
   icingaweb.resources.director-mysql.charset: utf8mb4
   icingaweb.resources.director-mysql.db: mysql
   icingaweb.resources.director-mysql.dbname: director
-  icingaweb.resources.director-mysql.host: mysql
+  icingaweb.resources.director-mysql.host: *mysql-host
   icingaweb.resources.director-mysql.password: ${ICINGA_DIRECTOR_MYSQL_PASSWORD:-director}
   icingaweb.resources.director-mysql.type: db
   icingaweb.resources.director-mysql.username: director
@@ -48,7 +53,7 @@ x-icinga-web-config:
   icingaweb.resources.icingaweb-mysql.charset: utf8mb4
   icingaweb.resources.icingaweb-mysql.db: mysql
   icingaweb.resources.icingaweb-mysql.dbname: icingaweb
-  icingaweb.resources.icingaweb-mysql.host: mysql
+  icingaweb.resources.icingaweb-mysql.host: *mysql-host
   icingaweb.resources.icingaweb-mysql.password: icingaweb
   icingaweb.resources.icingaweb-mysql.type: db
   icingaweb.resources.icingaweb-mysql.username: icingaweb
@@ -108,7 +113,8 @@ services:
       - ./init-icinga2.sh:/config/init-icinga2.sh:z
 
   icinga2:
-    container_name: icinga2
+    #container_name: icinga2
+    container_name: *icinga2-host
     command: [ "sh", "-c", "sleep 5 ; icinga2 daemon" ]
     depends_on:
       - icingadb-redis
@@ -123,7 +129,7 @@ services:
       - ./icinga2.conf.d:/custom_data/custom.conf.d:z
 
   icingadb:
-    container_name: icingadb
+    container_name: *icingadb-host
     environment:
       ICINGADB_DATABASE_HOST: mysql
       ICINGADB_DATABASE_PORT: 3306
@@ -139,7 +145,7 @@ services:
     logging: *default-logging
 
   icingadb-redis:
-    container_name: icingadb-redis
+    container_name: *icingadb-redis-host
     image: redis
     logging: *default-logging
 
@@ -155,7 +161,7 @@ services:
     logging: *default-logging
     image: icinga/icingaweb2
     ports:
-      - 8083:8080
+      - 8080:8080
     # Restart Icinga Web container automatically since we have to wait for the database to be ready.
     # Please note that this needs a more sophisticated solution.
     restart: on-failure
@@ -163,7 +169,7 @@ services:
       - icingaweb:/data
 
   mysql:
-    container_name: mysql
+    container_name: *mysql-host
     image: mariadb:10.7
     command: --default-authentication-plugin=mysql_native_password
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ networks:
 
 services:
   director:
+    container_name: director
     command:
       - /bin/bash
       - -ce
@@ -102,11 +103,12 @@ services:
     logging: *default-logging
     volumes:
       - icinga2:/data
-      - ./icingadb.conf:/config/icingadb.conf
-      - ./icingaweb-api-user.conf:/config/icingaweb-api-user.conf
-      - ./init-icinga2.sh:/config/init-icinga2.sh
+      - ./icingadb.conf:/config/icingadb.conf:z
+      - ./icingaweb-api-user.conf:/config/icingaweb-api-user.conf:z
+      - ./init-icinga2.sh:/config/init-icinga2.sh:z
 
   icinga2:
+    container_name: icinga2
     command: [ "sh", "-c", "sleep 5 ; icinga2 daemon" ]
     depends_on:
       - icingadb-redis
@@ -118,9 +120,10 @@ services:
       - 5665:5665
     volumes:
       - icinga2:/data
-      - ./icinga2.conf.d:/custom_data/custom.conf.d
+      - ./icinga2.conf.d:/custom_data/custom.conf.d:z
 
   icingadb:
+    container_name: icingadb
     environment:
       ICINGADB_DATABASE_HOST: mysql
       ICINGADB_DATABASE_PORT: 3306
@@ -136,10 +139,12 @@ services:
     logging: *default-logging
 
   icingadb-redis:
+    container_name: icingadb-redis
     image: redis
     logging: *default-logging
 
   icingaweb:
+    container_name: icingaweb
     depends_on:
       - mysql
     environment:
@@ -150,7 +155,7 @@ services:
     logging: *default-logging
     image: icinga/icingaweb2
     ports:
-      - 8080:8080
+      - 8083:8080
     # Restart Icinga Web container automatically since we have to wait for the database to be ready.
     # Please note that this needs a more sophisticated solution.
     restart: on-failure
@@ -158,6 +163,7 @@ services:
       - icingaweb:/data
 
   mysql:
+    container_name: mysql
     image: mariadb:10.7
     command: --default-authentication-plugin=mysql_native_password
     environment:
@@ -168,8 +174,8 @@ services:
     logging: *default-logging
     volumes:
       - mysql:/var/lib/mysql
-      - ./env/mysql/:/docker-entrypoint-initdb.d/
-
+      - ./env/mysql/:/docker-entrypoint-initdb.d/:z
+        
 volumes:
   icinga2:
   icingaweb:

--- a/init-icinga2.sh
+++ b/init-icinga2.sh
@@ -11,3 +11,8 @@ if [ ! -f /data/etc/icinga2/features-enabled/icingadb.conf ]; then
   mkdir -p /data/etc/icinga2/features-enabled
   cat /config/icingadb.conf >/data/etc/icinga2/features-enabled/icingadb.conf
 fi
+
+optional_confd=$(grep 'include_recursive "/custom_data/custom.conf.d"' /etc/icinga2/icinga2.conf)
+if [ -z "$optional_confd" ]; then
+  echo 'include_recursive "/custom_data/custom.conf.d"' >> /etc/icinga2/icinga2.conf
+fi


### PR DESCRIPTION
To use the docker-compose file for podman, it needs some modifications.
The following modifications are done:
 * Added Selinux volume options (the strange z's at the end of the volume-mount definitions)
 * Added container_name directive with variable container names (maybe there is a better way, but I'm not really well in docker-compose). This is needed, because of the dns resolution in podman.
 * Updated documentation
 * Bugfix in `init-icinga2.sh` script. In the past, the custom configuration files in `icinga2.conf.d` were not included into icinga2