### PR TITLE
compability to docker compose 2.17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,9 +144,7 @@ services:
       - mysql
     environment:
       icingaweb.enabledModules: director, icingadb, incubator
-      <<: *icinga-db-web-config
-      <<: *icinga-director-config
-      <<: *icinga-web-config
+      <<: [*icinga-db-web-config, *icinga-director-config, *icinga-web-config]
     logging: *default-logging
     image: icinga/icingaweb2
     ports:


### PR DESCRIPTION
upgrading docker compose from 2.16 to 2.17 lead to syntax errors in this file. Error was: yaml: unmarshal errors:
  line 180: mapping key "<<" already defined at line 179
  line 181: mapping key "<<" already defined at line 179
  line 181: mapping key "<<" already defined at line 180
The mapping key can not be specified multiple times. Changing it to an array made it work again.