### PR TITLE
Fix docker-compose error 'mapping key "<<" already defined'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,9 +144,7 @@ services:
       - mysql
     environment:
       icingaweb.enabledModules: director, icingadb, incubator
-      <<: *icinga-db-web-config
-      <<: *icinga-director-config
-      <<: *icinga-web-config
+      <<: [*icinga-db-web-config, *icinga-director-config, *icinga-web-config]
     logging: *default-logging
     image: icinga/icingaweb2
     ports:


### PR DESCRIPTION
Upgraded Docker for Mac, got that error.

https://github.com/docker/compose/issues/10411#issuecomment-1488019350 fixed it for me.