### PR TITLE
join repeated "<<"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,9 +144,9 @@ services:
       - mysql
     environment:
       icingaweb.enabledModules: director, icingadb, incubator
-      <<: *icinga-db-web-config
-      <<: *icinga-director-config
-      <<: *icinga-web-config
+      <<:  [ *icinga-web-config, 
+             *icinga-db-web-config,
+             *icinga-director-config ]
     logging: *default-logging
     image: icinga/icingaweb2
     ports:


### PR DESCRIPTION
https://github.com/docker/compose/issues/10411

repeated "<<" break docker-compose >= 2.17

yaml: unmarshal errors:
  line 148: mapping key "<<" already defined at line 147