### PR TITLE
doc: mysql permissions error and mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Icinga Web is provided on port **8080** and you can access the Icinga 2 API on p
 The default user of Icinga Web is `icingaadmin` with password `icinga` and
 the default user of the Icinga 2 API for Web is `icingaweb` with password `icingaweb`.
 
+## Recent image changes ##
+
+Notes on deployment failure related to MySQL permissions are in :
+  doc/mysql-cannot-open-directory-docker-entrypoint-initdb.md
+
+
 ## Upgrading from v1.1.0 to v1.2.0
 
 **v1.2.0** deploys Icinga Web ≥ 2.11.0, Icinga 2 ≥ 2.13.4, Icinga DB ≥ 1.0.0 and Icinga DB Web ≥ 1.0.0.

--- a/doc/mysql-cannot-open-directory-docker-entrypoint-initdb.md
+++ b/doc/mysql-cannot-open-directory-docker-entrypoint-initdb.md
@@ -1,0 +1,47 @@
+## Deploying as non-root ##
+
+(deployment notes from a user)
+
+I wanted to document a problem and a fix.
+
+Having not defined a version of the images to deploy, effectively defaulting to "latest", the
+deployed images might have changed behavior.  It would probably benefit re-use to pin versions that
+work and upgrade deliberately as upstream upgrades.
+
+In addition but unrelated, deploying as a nonroot user without permission to the "docker" nor
+"docker-compose" apps without "sudo" might be different than the original author did.  For this
+reason, my environment might be a source of entropy here.
+
+This was failing:
+```
+mysql_1           | ls: cannot open directory '/docker-entrypoint-initdb.d/': Permission denied
+```
+
+This can be confirmed with a basic "up" of the database itself:
+```
+    sudo docker-compose -p icinga-playground up mysql
+```
+
+a blanket/broad chmod of the path mapped this "/docker-entrypoint-initdb.d" mitigates:
+```
+    chmod -R ugo+rx  env/mysql
+```
+
+### Versions ###
+
+containers:
+icinga/icingaweb2:2.11.4
+mariadb:10.7
+
+CLI:
+docker-compose version 1.28.5, build 24fb474e
+ - docker-py 4.4.4
+ - CPython 3.7.10
+ - OpenSSL OpenSSL 1.1.0l
+Docker version 20.10.3, build 55f0773
+ - API 1.41
+ - go-1.17.1
+ - docker engine 20.10.3
+ - containerd 1.4.3
+ - runc 1.0.0-rc93 hash 31cc25f16f5e
+ - docker-init 0.19.0


### PR DESCRIPTION
Running into a deployment issue, I wanted to document the mitigation.

The TL;DR is:   mitigate before `docker-compose up` using: `chmod -R ugo+rx  env/mysql`

Of note: my docker-compose is a `1.28` whereas the most recent commit(s) have upgraded for a docker-compose `2.7`.  That may be the source of my issue, and if so, I'd prefer to still document it for others in case it's related to an evolving `mariadb` container.

